### PR TITLE
Mice in maints as ghost spawners

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -1,3 +1,5 @@
+#define MOUSE_GHOST_ROLE_ENABLED TRUE
+
 /mob/living/simple_animal/mouse
 	name = "mouse"
 	desc = "It's a nasty, ugly, evil, disease-ridden rodent."
@@ -25,6 +27,7 @@
 	var/body_color //brown, gray and white, leave blank for random
 	gold_core_spawnable = FRIENDLY_SPAWN
 	var/chew_probability = 1
+	var/time_to_chew = 5
 	mobsay_color = "#82AF84"
 	var/list/ratdisease = list()
 	can_be_held = TRUE
@@ -42,6 +45,61 @@
 		var/datum/disease/advance/R = new /datum/disease/advance/random(rand(2, 4))
 		ratdisease += R
 
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE //make mice see in the dark
+	if(MOUSE_GHOST_ROLE_ENABLED && is_maintenance_mouse())
+		add_to_spawner_menu()
+	RegisterSignal(src, COMSIG_MOB_SAY, .proc/handle_speech) //make mice unable to be communicate
+
+/mob/living/simple_animal/mouse/sentience_act()
+	. = ..()
+	UnregisterSignal(src, COMSIG_MOB_SAY) //though when sentience is applied, mice should regain their ability of speech 
+
+/mob/living/simple_animal/mouse/ghostize(can_reenter_corpse = TRUE)
+	. = ..()
+	if(. && stat != DEAD)
+		add_to_spawner_menu()
+
+/mob/living/simple_animal/mouse/proc/is_maintenance_mouse()
+	var/turf/T = get_turf(src)
+	if(!T || !is_station_level(T.z) || !is_station_level(z))
+		return FALSE
+	if(gold_core_spawnable == NO_SPAWN) //since Tom isn't a pet and we can not check the unique_pet variable, we will use gold_core_spawnable check as a kludge
+		return FALSE
+	return TRUE
+
+/mob/living/simple_animal/mouse/proc/add_to_spawner_menu()
+	LAZYADD(GLOB.mob_spawners["Maintenance mouse"], src)
+	GLOB.poi_list |= src
+
+/mob/living/simple_animal/mouse/get_spawner_desc()
+	return "Do your business with the cheese and squeaking." //a mild reference to the hitchhiker's guide to the galaxy
+
+/mob/living/simple_animal/mouse/get_spawner_flavour_text()
+	return "You are a maintenance mouse. Cooperate with your fellow mice to go on a holy crusade for some cheese or just get toasted by gnawing the first cable you find."
+
+/mob/living/simple_animal/mouse/attack_ghost(mob/user)
+	. = ..()
+	if(key || stat || !MOUSE_GHOST_ROLE_ENABLED)
+		return
+	var/mouse_ask = alert("Do you really want to become a mouse?", "Become a mouse?", "Yes", "No")
+	if(mouse_ask == "No" || QDELETED(src))
+		return
+	if(key)
+		to_chat(user, "<span class='warning'>Someone else already took this mouse!</span>")
+		return
+	key = user.key
+	remove_from_spawner_menu()
+	log_game("[key_name(src)] took control of [name].")
+
+/mob/living/simple_animal/mouse/proc/remove_from_spawner_menu()
+	for(var/spawner in GLOB.mob_spawners)
+		LAZYREMOVE(GLOB.mob_spawners[spawner], src)
+	GLOB.poi_list -= src
+
+/mob/living/simple_animal/mouse/proc/handle_speech(datum/source, list/speech_args)
+	speech_args[SPEECH_MESSAGE] = pick(speak)
+	playsound(src, 'sound/effects/mousesqueek.ogg', 100, 1)
+
 /mob/living/simple_animal/mouse/extrapolator_act(mob/user, var/obj/item/extrapolator/E, scan = TRUE)
 	if(!ratdisease.len)
 		return FALSE
@@ -50,7 +108,6 @@
 	else
 		E.extrapolate(src, ratdisease, user)
 	return TRUE
-
 
 /mob/living/simple_animal/mouse/proc/splat()
 	src.health = 0
@@ -86,14 +143,23 @@
 		if(istype(F) && !F.intact)
 			var/obj/structure/cable/C = locate() in F
 			if(C && prob(15))
-				if(C.avail())
-					visible_message("<span class='warning'>[src] chews through the [C]. It's toast!</span>")
-					playsound(src, 'sound/effects/sparks2.ogg', 100, 1)
-					C.deconstruct()
-					death(toast=1)
-				else
-					C.deconstruct()
-					visible_message("<span class='warning'>[src] chews through the [C].</span>")
+				chew_cable(C)
+
+obj/structure/cable/attack_animal(mob/living/simple_animal/mouse/user)
+	. = ..()
+	to_chat(user, "<span class='notice'>You begin ravenously shredding insulation on [src] with your teeth...</span>")
+	if(do_after(user, user.time_to_chew, TRUE, src))
+		user.chew_cable(src)
+
+/mob/living/simple_animal/mouse/proc/chew_cable(var/obj/structure/cable/C)
+	if(C.avail())
+		visible_message("<span class='warning'>[src] chews through [C]. It's toast!</span>")
+		playsound(src, 'sound/effects/sparks2.ogg', 100, 1)
+		C.deconstruct()
+		death(toast=1)
+	else
+		C.deconstruct()
+		visible_message("<span class='warning'>[src] chews through [C].</span>")
 
 /*
  * Mouse types


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds every mouse spawned in maintenance corridors to the ghost spawners menu. Mice are unable to communicate via speech until they gain sentience. Player-controlled mice now also have the ability to chew power cabels and die because of that as well as the original simplemobs used to.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ghost players now gain the ability to squeak at the crew, to gnaw power cables and to organize a march into the SM crystal.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: maint mice ghost spawners
code: minor changes in mouse.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->